### PR TITLE
test: implement tests for App Router components

### DIFF
--- a/src/app/json/parse/page.test.tsx
+++ b/src/app/json/parse/page.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import JSONParse from './page'
+import '@testing-library/jest-dom'
+
+describe('JSON Parse Page', () => {
+  it('renders DeveloperHelpToolFrame and subTitle', () => {
+    render(<JSONParse />)
+    expect(screen.getByText('JSON Parse Tool')).toBeInTheDocument()
+    expect(screen.getByText('Developer Help Tool')).toBeInTheDocument()
+  })
+})

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Home from './page'
+import '@testing-library/jest-dom'
+
+describe('Home Page', () => {
+  it('renders DeveloperHelpToolFrame and subTitle', () => {
+    render(<Home />)
+    expect(screen.getByText('index page')).toBeInTheDocument()
+    expect(screen.getByText('Developer Help Tool')).toBeInTheDocument()
+  })
+
+  it('renders ToolList links', () => {
+    render(<Home />)
+    expect(screen.getByText('JSON Parse Tool')).toBeInTheDocument()
+    expect(screen.getByText('String Replace Tool')).toBeInTheDocument()
+    expect(screen.getByText('Url Encode And Decode Tool')).toBeInTheDocument()
+    expect(screen.getByText('Url Parse Tool')).toBeInTheDocument()
+  })
+})

--- a/src/app/string/replace/page.test.tsx
+++ b/src/app/string/replace/page.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import StringReplace from './page'
+import '@testing-library/jest-dom'
+
+describe('String Replace Page', () => {
+  it('renders DeveloperHelpToolFrame and subTitle', () => {
+    render(<StringReplace />)
+    expect(screen.getByText('String Replace Tool')).toBeInTheDocument()
+    expect(screen.getByText('Developer Help Tool')).toBeInTheDocument()
+  })
+})

--- a/src/app/url/encode/page.test.tsx
+++ b/src/app/url/encode/page.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import UrlEncode from './page'
+import '@testing-library/jest-dom'
+
+describe('Url Encode Page', () => {
+  it('renders DeveloperHelpToolFrame and subTitle', () => {
+    render(<UrlEncode />)
+    expect(screen.getByText('Url Encode And Decode Tool')).toBeInTheDocument()
+    expect(screen.getByText('Developer Help Tool')).toBeInTheDocument()
+  })
+})

--- a/src/app/url/parse/page.test.tsx
+++ b/src/app/url/parse/page.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import UrlParse from './page'
+import '@testing-library/jest-dom'
+
+describe('Url Parse Page', () => {
+  it('renders DeveloperHelpToolFrame and subTitle', () => {
+    render(<UrlParse />)
+    expect(screen.getByText('Url Parse Tool')).toBeInTheDocument()
+    expect(screen.getByText('Developer Help Tool')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Implemented tests for the newly migrated Next.js App Router components as per Step 5 of the MIGRATION_PLAN.md. Created tests for:
- src/app/page.tsx
- src/app/json/parse/page.tsx
- src/app/string/replace/page.tsx
- src/app/url/encode/page.tsx
- src/app/url/parse/page.tsx

Using React Testing Library and jest-dom to render the pages and assert that the expected `DeveloperHelpToolFrame` and tool components are rendered successfully. All newly added and existing tests are passing.

---
*PR created automatically by Jules for task [777634249569961766](https://jules.google.com/task/777634249569961766) started by @eno314*