### PR TITLE
chore: update dependabot schedule to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,13 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "saturday"
-      time: "07:00"
+      interval: "monthly"
+      time: "06:00"
       timezone: "Asia/Tokyo"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "saturday"
-      time: "07:00"
+      interval: "monthly"
+      time: "06:00"
       timezone: "Asia/Tokyo"


### PR DESCRIPTION
I updated `.github/dependabot.yml` to change the update interval from `weekly` to `monthly` for both `npm` and `github-actions` ecosystems, and set the time to `06:00` in the `Asia/Tokyo` timezone. Dependabot interprets `monthly` as running on the 1st of the month.

---
*PR created automatically by Jules for task [387847188553152108](https://jules.google.com/task/387847188553152108) started by @eno314*