### PR TITLE
test: add e2e tests for JSON parse tool page

### DIFF
--- a/playwright_tests/jsonParse.spec.ts
+++ b/playwright_tests/jsonParse.spec.ts
@@ -1,0 +1,44 @@
+import {test, expect} from '@playwright/test';
+
+test.describe('JSON Parse Tool Tests', () => {
+  test('should parse JSON string with object and array successfully', async ({
+    page,
+  }) => {
+    // Navigate to the JSON Parse Tool page
+    await page.goto('/json/parse');
+
+    // Input JSON string
+    const inputJson = JSON.stringify(
+      {
+        user: {
+          name: 'Alice',
+          age: 30,
+        },
+        tags: ['developer', 'typescript'],
+      },
+      null,
+      2
+    );
+
+    const expectedParsedResult = `object(
+  user : object(
+    name : Alice
+    age : 30
+  )
+  tags : object(
+    0 : developer
+    1 : typescript
+  )
+)`;
+
+    // Fill the input textarea
+    await page.fill('#jsonTextarea', inputJson);
+
+    // Click the "Parse JSON" button
+    await page.click('button:has-text("Parse JSON")');
+
+    // Verify the output in the result textarea
+    const resultTextarea = page.locator('#resultTextarea');
+    await expect(resultTextarea).toHaveValue(expectedParsedResult);
+  });
+});


### PR DESCRIPTION
Adds a new Playwright e2e test for the JSON Parse Tool page to cover the Happy Path functionality.

The test ensures that when a user inputs a JSON string containing objects and arrays and clicks "Parse JSON", the correct parsed result appears in the output area.

---
*PR created automatically by Jules for task [3790930338833557184](https://jules.google.com/task/3790930338833557184) started by @eno314*