### PR TITLE
Add Playwright test for String Replace page

### DIFF
--- a/playwright_tests/string_replace.spec.ts
+++ b/playwright_tests/string_replace.spec.ts
@@ -1,0 +1,28 @@
+import {test, expect} from '@playwright/test';
+
+test.describe('String Replace Page Tests', () => {
+  test.beforeEach(async ({page}) => {
+    await page.goto('/string/replace');
+  });
+
+  test('should successfully replace a substring', async ({page}) => {
+    // Fill the original text textarea
+    const textareaLabel = "Please input text you'd like to replace.";
+    await page.getByLabel(textareaLabel).fill('hello world');
+
+    // Fill the target substring
+    await page.locator('input[aria-describedby="targetSubstr"]').fill('world');
+
+    // Fill the new substring
+    await page
+      .locator('input[aria-describedby="newSubstr"]')
+      .fill('playwright');
+
+    // Click the Apply button
+    await page.getByRole('button', {name: '▼ Apply'}).click();
+
+    // Verify the result textarea
+    const resultTextarea = page.locator('#newTextarea');
+    await expect(resultTextarea).toHaveValue('hello playwright');
+  });
+});


### PR DESCRIPTION
Add a Happy Path Playwright test to verify the functionality of the `/string/replace` tool page.

## Changes:
- **`playwright_tests/string_replace.spec.ts`**: Created a new Playwright test file. The test specifically addresses:
  - Navigating to the String Replace Tool page.
  - Setting original string text via the main textarea.
  - Populating the "target substr" and "new substr" input fields.
  - Submitting the form and asserting the replaced text matches expected outcomes.

---
*PR created automatically by Jules for task [10444814545123841001](https://jules.google.com/task/10444814545123841001) started by @eno314*