### PR TITLE
Add Playwright test for URL encode and decode page

### DIFF
--- a/playwright_tests/url_encode.spec.ts
+++ b/playwright_tests/url_encode.spec.ts
@@ -1,20 +1,15 @@
 import {test, expect} from '@playwright/test';
 
 test.describe('Url Encode And Decode Tool', () => {
-  test('should encode and decode URL with multibyte query parameters', async ({
-    page,
-  }) => {
+  test.beforeEach(async ({page}) => {
     await page.goto('/url/encode');
+  });
 
+  test('should encode URL with multibyte query parameters', async ({page}) => {
     // Encode test data
     const urlToEncode = 'https://example.com/search?q1=テスト&p2=エンコード';
     const expectedEncodedUrl = encodeURIComponent(urlToEncode);
 
-    // Decode test data
-    const urlToDecode = 'https://example.com/search?q1=テスト&p2=デコード';
-    const encodedUrlToDecode = encodeURIComponent(urlToDecode);
-
-    // Step 1: Encode a URL
     // Fill the textarea associated with "Please input text you'd like to encode."
     await page
       .getByLabel("Please input text you'd like to encode.")
@@ -27,8 +22,13 @@ test.describe('Url Encode And Decode Tool', () => {
     await expect(
       page.getByLabel("Please input text you'd like to decode."),
     ).toHaveValue(expectedEncodedUrl);
+  });
 
-    // Step 2: Decode a URL
+  test('should decode URL with multibyte query parameters', async ({page}) => {
+    // Decode test data
+    const urlToDecode = 'https://example.com/search?q1=テスト&p2=デコード';
+    const encodedUrlToDecode = encodeURIComponent(urlToDecode);
+
     // Fill the textarea associated with "Please input text you'd like to decode."
     await page
       .getByLabel("Please input text you'd like to decode.")


### PR DESCRIPTION
This PR adds an end-to-end Playwright test to verify that the URL Encode/Decode tool works correctly for multibyte queries. It tests:
1. Encoding a string containing Japanese characters and verifying the output.
2. Decoding that generated string back into Japanese characters and verifying the output.

---
*PR created automatically by Jules for task [10483463456897588581](https://jules.google.com/task/10483463456897588581) started by @eno314*