### PR TITLE
feat: add playwright test for amidakuji page and restrict editing inputs on generation

### DIFF
--- a/playwright_tests/amidakuji.spec.ts
+++ b/playwright_tests/amidakuji.spec.ts
@@ -1,0 +1,127 @@
+import {test, expect} from '@playwright/test';
+
+test.describe('Amidakuji Page Tests - Happy Path', () => {
+  test.beforeEach(async ({page}) => {
+    await page.goto('/amidakuji');
+  });
+
+  test('should verify the number of vertical lines for 2 and 15', async ({
+    page,
+  }) => {
+    const numLinesInput = page.getByLabel('Number of Lines (2-15):');
+
+    // Test for 2 lines
+    await numLinesInput.fill('2');
+    await numLinesInput.blur();
+
+    // There are top and bottom labels, we count the SVG lines
+    // Get the vertical lines. They are simple <line> elements that have y1=20.
+    // However, it's easier to count the total lines minus the horizontal ones if they exist,
+    // or since no generation has occurred, all <line> elements are vertical lines.
+    let lines = page.locator('svg line');
+    await expect(lines).toHaveCount(2);
+
+    // Test for 15 lines
+    await numLinesInput.fill('15');
+    await numLinesInput.blur();
+
+    lines = page.locator('svg line');
+    await expect(lines).toHaveCount(15);
+  });
+
+  test('should allow editing start and end points in the initial state', async ({
+    page,
+  }) => {
+    // Top labels
+    const topInputs = page
+      .locator('div[class*="labelsRow"]')
+      .first()
+      .locator('input[type="text"]');
+    await topInputs.nth(0).fill('Start 1');
+    await expect(topInputs.nth(0)).toHaveValue('Start 1');
+    await expect(topInputs.nth(0)).not.toHaveAttribute('readonly');
+
+    // Bottom labels
+    const bottomInputs = page
+      .locator('div[class*="labelsRow"]')
+      .last()
+      .locator('input[type="text"]');
+    await bottomInputs.nth(0).fill('End 1');
+    await expect(bottomInputs.nth(0)).toHaveValue('End 1');
+    await expect(bottomInputs.nth(0)).not.toHaveAttribute('readonly');
+  });
+
+  test('should disable editing, draw lines, and show red path upon generation and selection', async ({
+    page,
+  }) => {
+    // Generate lines
+    await page.getByRole('button', {name: '生成 (Generate)'}).click();
+
+    // Verify horizontal lines are generated (total lines > 5 since default is 5 vertical lines + some horizontal lines)
+    const lines = page.locator('svg line');
+    const linesCount = await lines.count();
+    expect(linesCount).toBeGreaterThan(5);
+
+    // Verify inputs are readonly
+    const topInputs = page
+      .locator('div[class*="labelsRow"]')
+      .first()
+      .locator('input[type="text"]');
+    await expect(topInputs.nth(0)).toHaveAttribute('readonly', '');
+
+    const bottomInputs = page
+      .locator('div[class*="labelsRow"]')
+      .last()
+      .locator('input[type="text"]');
+    await expect(bottomInputs.nth(0)).toHaveAttribute('readonly', '');
+
+    // Select a start point to draw the red path
+    await page.getByRole('button', {name: 'Select'}).first().click();
+
+    // Verify the red path (polyline with stroke="red") is rendered
+    const redPath = page.locator('svg polyline[stroke="red"]');
+    await expect(redPath).toBeVisible();
+  });
+
+  test('should reset to initial state upon clicking clear', async ({page}) => {
+    const numLinesInput = page.getByLabel('Number of Lines (2-15):');
+    await numLinesInput.fill('3');
+    await numLinesInput.blur();
+
+    const topInputs = page
+      .locator('div[class*="labelsRow"]')
+      .first()
+      .locator('input[type="text"]');
+    await topInputs.nth(0).fill('Start 1');
+
+    await page.getByRole('button', {name: '生成 (Generate)'}).click();
+    await page.getByRole('button', {name: 'Select'}).first().click();
+
+    // Clear
+    await page.getByRole('button', {name: 'クリア (Clear)'}).click();
+
+    // Verify initial state
+    // 1. Only 3 vertical lines (no horizontal lines)
+    const lines = page.locator('svg line');
+    await expect(lines).toHaveCount(3);
+
+    // 2. No red path
+    const redPath = page.locator('svg polyline[stroke="red"]');
+    await expect(redPath).toHaveCount(0);
+
+    // 3. Inputs are editable again and reset to default values (1, 2, 3...)
+    await expect(topInputs.nth(0)).not.toHaveAttribute('readonly');
+    await expect(topInputs.nth(0)).toHaveValue('1');
+    await expect(topInputs.nth(1)).toHaveValue('2');
+    await expect(topInputs.nth(2)).toHaveValue('3');
+
+    const bottomInputs = page
+      .locator('div[class*="labelsRow"]')
+      .last()
+      .locator('input[type="text"]');
+    await expect(bottomInputs.nth(0)).not.toHaveAttribute('readonly');
+    await expect(bottomInputs.nth(0)).toHaveValue('1');
+    await expect(bottomInputs.nth(1)).toHaveValue('2');
+    await expect(bottomInputs.nth(2)).toHaveValue('3');
+  });
+});

--- a/src/components/organisms/Amidakuji/Amidakuji.tsx
+++ b/src/components/organisms/Amidakuji/Amidakuji.tsx
@@ -281,6 +281,7 @@ const Amidakuji = (): React.JSX.Element => {
                 value={label}
                 onChange={e => handleLabelChange(i, e.target.value, true)}
                 onClick={() => isGenerated && setSelectedStart(i)}
+                readOnly={isGenerated}
                 style={{
                   cursor: isGenerated ? 'pointer' : 'text',
                   borderColor: selectedStart === i ? 'red' : undefined,
@@ -321,6 +322,7 @@ const Amidakuji = (): React.JSX.Element => {
                   className={`form-control ${styles.labelInput}`}
                   value={label}
                   onChange={e => handleLabelChange(i, e.target.value, false)}
+                  readOnly={isGenerated}
                   style={{
                     borderColor: isEndNode ? 'red' : undefined,
                     borderWidth: isEndNode ? '2px' : undefined,


### PR DESCRIPTION
Added a Playwright test script for the `amidakuji` page following the happy path logic. To correctly assert on read-only constraints after clicking Generate, also updated `Amidakuji.tsx` to set the inputs to readOnly.

Test verification:
- Generated vertical line count
- Initial state editing capabilities
- Post-generation drawing of path and readonly constraints
- Returning to initial state via Clear

Tested tests successfully using `npx playwright test playwright_tests/amidakuji.spec.ts`.

---
*PR created automatically by Jules for task [17953851869922457301](https://jules.google.com/task/17953851869922457301) started by @eno314*