### PR TITLE
feat: add regex support placeholder and tests to String Replace Tool

### DIFF
--- a/playwright_tests/string_replace.spec.ts
+++ b/playwright_tests/string_replace.spec.ts
@@ -25,4 +25,29 @@ test.describe('String Replace Page Tests', () => {
     const resultTextarea = page.locator('#newTextarea');
     await expect(resultTextarea).toHaveValue('hello playwright');
   });
+
+  test('should successfully replace a substring using regular expression', async ({
+    page,
+  }) => {
+    // Fill the original text textarea
+    const textareaLabel = "Please input text you'd like to replace.";
+    await page
+      .getByLabel(textareaLabel)
+      .fill('The quick brown fox jumps over 13 lazy dogs.');
+
+    // Fill the target substring
+    await page.locator('input[aria-describedby="targetSubstr"]').fill('\\d+');
+
+    // Fill the new substring
+    await page.locator('input[aria-describedby="newSubstr"]').fill('the');
+
+    // Click the Apply button
+    await page.getByRole('button', {name: '▼ Apply'}).click();
+
+    // Verify the result textarea
+    const resultTextarea = page.locator('#newTextarea');
+    await expect(resultTextarea).toHaveValue(
+      'The quick brown fox jumps over the lazy dogs.',
+    );
+  });
 });

--- a/src/components/molecules/StringReplaceForm/StringReplaceForm.test.tsx
+++ b/src/components/molecules/StringReplaceForm/StringReplaceForm.test.tsx
@@ -40,4 +40,18 @@ describe('onClickReplace', () => {
 
     expect(textBoxes[3]).toHaveValue('aaaa\tbbbb\tcccc');
   });
+
+  test('Text of replacedTextarea should replace using regular expression', () => {
+    render(<StringReplaceForm />);
+
+    const textBoxes = screen.getAllByRole('textbox');
+    const buttons = screen.getAllByRole('button');
+
+    fireEvent.change(textBoxes[0], {target: {value: 'hello world 123'}});
+    fireEvent.change(textBoxes[1], {target: {value: '\\d+'}});
+    fireEvent.change(textBoxes[2], {target: {value: 'X'}});
+    fireEvent.click(buttons[0]);
+
+    expect(textBoxes[3]).toHaveValue('hello world X');
+  });
 });

--- a/src/components/molecules/StringReplaceForm/StringReplaceForm.tsx
+++ b/src/components/molecules/StringReplaceForm/StringReplaceForm.tsx
@@ -47,6 +47,7 @@ const StringReplaceForm = (): React.JSX.Element => {
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               setTargetSubstr(e.target.value);
             }}
+            placeholder={'Supports regular expression'}
             type={'text'}
             value={targetSubstr}
           />


### PR DESCRIPTION
This branch implements the user request to visually document that the String Replace Tool supports regular expressions. It adds a placeholder to the `targetSubstr` input field. It also adds tests in both Jest and Playwright to verify that regex substitution works seamlessly.

---
*PR created automatically by Jules for task [8815241049193827299](https://jules.google.com/task/8815241049193827299) started by @eno314*