### PR TITLE
feat: Add Curl Builder Tool page

### DIFF
--- a/playwright_tests/curl_builder.spec.ts
+++ b/playwright_tests/curl_builder.spec.ts
@@ -1,0 +1,75 @@
+import {test, expect} from '@playwright/test';
+
+test.describe('Curl Builder Tool Tests', () => {
+  test.beforeEach(async ({page}) => {
+    await page.goto('/curl/builder');
+  });
+
+  test('should generate default curl command', async ({page}) => {
+    await expect(page).toHaveTitle('Developer Help Tool - Curl Builder Tool');
+
+    const outputTextarea = page.locator('textarea[readonly]');
+    await expect(outputTextarea).toHaveValue('curl ""');
+  });
+
+  test('should update curl command when URL is entered', async ({page}) => {
+    await page.fill('input[type="text"] >> nth=0', 'https://example.com/api');
+
+    const outputTextarea = page.locator('textarea[readonly]');
+    await expect(outputTextarea).toHaveValue('curl "https://example.com/api"');
+  });
+
+  test('should handle changing method to POST and add body', async ({page}) => {
+    // URL
+    await page.fill('input[type="text"] >> nth=0', 'http://localhost');
+
+    // Method
+    await page.selectOption('select', 'POST');
+
+    // Output should update
+    const outputTextarea = page.locator('textarea[readonly]');
+    await expect(outputTextarea).toHaveValue('curl -X POST "http://localhost"');
+
+    // Fill Body
+    await page.fill('textarea[placeholder="Request Body"]', '{"test": 123}');
+
+    await expect(outputTextarea).toHaveValue(
+      'curl -X POST "http://localhost" -d \'{"test": 123}\'',
+    );
+  });
+
+  test('should add, edit, and remove headers', async ({page}) => {
+    // Add header
+    await page.click('text="+ Add Header"');
+
+    // Fill Header 1
+    await page.fill(
+      'input[placeholder="Key (e.g., Content-Type)"]',
+      'Authorization',
+    );
+    await page.fill(
+      'input[placeholder="Value (e.g., application/json)"]',
+      'Bearer token',
+    );
+
+    const outputTextarea = page.locator('textarea[readonly]');
+    await expect(outputTextarea).toHaveValue(
+      'curl "" -H "Authorization: Bearer token"',
+    );
+
+    // Remove Header
+    await page.click('button[aria-label="Remove header"]');
+    await expect(outputTextarea).toHaveValue('curl ""');
+  });
+
+  test('should verify body quote escaping', async ({page}) => {
+    await page.selectOption('select', 'PUT');
+
+    await page.fill('textarea[placeholder="Request Body"]', "It's a test");
+
+    const outputTextarea = page.locator('textarea[readonly]');
+    await expect(outputTextarea).toHaveValue(
+      "curl -X PUT \"\" -d 'It'\\''s a test'",
+    );
+  });
+});

--- a/playwright_tests/index.spec.ts
+++ b/playwright_tests/index.spec.ts
@@ -36,6 +36,11 @@ test.describe('Index Page Navigation Tests', () => {
       expectedPath: '/base64/encode',
       expectedTitle: 'Developer Help Tool - Base64 Encode And Decode Tool',
     },
+    {
+      text: 'Curl Builder Tool',
+      expectedPath: '/curl/builder',
+      expectedTitle: 'Developer Help Tool - Curl Builder Tool',
+    },
   ];
 
   for (const link of linksToTest) {

--- a/src/app/curl/builder/page.test.tsx
+++ b/src/app/curl/builder/page.test.tsx
@@ -1,0 +1,16 @@
+import {render, screen} from '@testing-library/react';
+import CurlBuilder from './page';
+
+describe('CurlBuilder page', () => {
+  it('renders DeveloperHelpToolFrame and subTitle', () => {
+    render(<CurlBuilder />);
+    const subTitle = screen.getByText('Curl Builder Tool');
+    expect(subTitle).toBeInTheDocument();
+  });
+
+  it('renders CurlBuilderForm inside content', () => {
+    render(<CurlBuilder />);
+    const generatedLabel = screen.getByText('Generated curl Command');
+    expect(generatedLabel).toBeInTheDocument();
+  });
+});

--- a/src/app/curl/builder/page.tsx
+++ b/src/app/curl/builder/page.tsx
@@ -1,0 +1,19 @@
+import type {Metadata} from 'next';
+import DeveloperHelpToolFrame from '@/components/molecules/DeveloperHelpToolFrame/DeveloperHelpToolFrame';
+import CurlBuilderForm from '@/components/organisms/CurlBuilderForm/CurlBuilderForm';
+import React from 'react';
+
+export const metadata: Metadata = {
+  title: 'Developer Help Tool - Curl Builder Tool',
+};
+
+const CurlBuilder = (): React.JSX.Element => {
+  return (
+    <DeveloperHelpToolFrame
+      subTitle={'Curl Builder Tool'}
+      content={<CurlBuilderForm />}
+    />
+  );
+};
+
+export default CurlBuilder;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,6 +43,11 @@ const links = [
     title: 'Base64 Encode And Decode Tool',
     description: 'You can encode and decode base64 by this tool.',
   },
+  {
+    linkPath: '/curl/builder',
+    title: 'Curl Builder Tool',
+    description: 'You can build curl command by this tool.',
+  },
 ];
 
 const Home = (): React.JSX.Element => {

--- a/src/components/organisms/CurlBuilderForm/CurlBuilderForm.test.tsx
+++ b/src/components/organisms/CurlBuilderForm/CurlBuilderForm.test.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import {render, screen, fireEvent, act} from '@testing-library/react';
+import CurlBuilderForm from './CurlBuilderForm';
+
+// Mock clipboard API
+Object.assign(navigator, {
+  clipboard: {
+    writeText: jest.fn(),
+  },
+});
+
+describe('CurlBuilderForm', () => {
+  beforeEach(() => {
+    (navigator.clipboard.writeText as jest.Mock).mockClear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('renders initial state correctly', () => {
+    render(<CurlBuilderForm />);
+
+    expect(screen.getByLabelText('Method')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('GET')).toBeInTheDocument();
+
+    expect(screen.getByLabelText('URL')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Body')).not.toBeInTheDocument();
+
+    expect(screen.getByText('No headers added.')).toBeInTheDocument();
+
+    const output = screen.getByDisplayValue('curl ""');
+    expect(output).toBeInTheDocument();
+  });
+
+  it('updates curl command when URL is changed', () => {
+    render(<CurlBuilderForm />);
+
+    const urlInput = screen.getByPlaceholderText(
+      'https://example.com/api?query=1',
+    );
+    fireEvent.change(urlInput, {
+      target: {value: 'https://api.github.com/users'},
+    });
+
+    expect(
+      screen.getByDisplayValue('curl "https://api.github.com/users"'),
+    ).toBeInTheDocument();
+  });
+
+  it('updates curl command when method is changed to POST and body is added', () => {
+    render(<CurlBuilderForm />);
+
+    const urlInput = screen.getByPlaceholderText(
+      'https://example.com/api?query=1',
+    );
+    fireEvent.change(urlInput, {target: {value: 'http://localhost/api'}});
+
+    const methodSelect = screen.getByLabelText('Method');
+    fireEvent.change(methodSelect, {target: {value: 'POST'}});
+
+    expect(
+      screen.getByDisplayValue('curl -X POST "http://localhost/api"'),
+    ).toBeInTheDocument();
+
+    const bodyTextarea = screen.getByPlaceholderText('Request Body');
+    expect(bodyTextarea).toBeInTheDocument();
+
+    fireEvent.change(bodyTextarea, {target: {value: '{"name": "test"}'}});
+
+    expect(
+      screen.getByDisplayValue(
+        'curl -X POST "http://localhost/api" -d \'{"name": "test"}\'',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('escapes single quotes in body', () => {
+    render(<CurlBuilderForm />);
+
+    const methodSelect = screen.getByLabelText('Method');
+    fireEvent.change(methodSelect, {target: {value: 'POST'}});
+
+    const bodyTextarea = screen.getByPlaceholderText('Request Body');
+    fireEvent.change(bodyTextarea, {target: {value: "It's a test 'body'"}});
+
+    expect(
+      screen.getByDisplayValue(
+        "curl -X POST \"\" -d 'It'\\''s a test '\\''body'\\'''",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('adds, updates, and removes headers', () => {
+    render(<CurlBuilderForm />);
+
+    const addHeaderBtn = screen.getByText('+ Add Header');
+    fireEvent.click(addHeaderBtn);
+
+    expect(screen.queryByText('No headers added.')).not.toBeInTheDocument();
+
+    const keyInput = screen.getByPlaceholderText('Key (e.g., Content-Type)');
+    const valueInput = screen.getByPlaceholderText(
+      'Value (e.g., application/json)',
+    );
+
+    fireEvent.change(keyInput, {target: {value: 'Content-Type'}});
+    fireEvent.change(valueInput, {target: {value: 'application/json'}});
+
+    expect(
+      screen.getByDisplayValue('curl "" -H "Content-Type: application/json"'),
+    ).toBeInTheDocument();
+
+    const removeBtn = screen.getByRole('button', {name: 'Remove header'});
+    fireEvent.click(removeBtn);
+
+    expect(screen.getByText('No headers added.')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('curl ""')).toBeInTheDocument();
+  });
+
+  it('copies command to clipboard and shows feedback', async () => {
+    (navigator.clipboard.writeText as jest.Mock).mockResolvedValueOnce(
+      undefined,
+    );
+
+    render(<CurlBuilderForm />);
+
+    const urlInput = screen.getByPlaceholderText(
+      'https://example.com/api?query=1',
+    );
+    fireEvent.change(urlInput, {target: {value: 'http://test.com'}});
+
+    const copyBtn = screen.getByText('Copy');
+
+    await act(async () => {
+      fireEvent.click(copyBtn);
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      'curl "http://test.com"',
+    );
+    expect(screen.getByText('Copied!')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(screen.getByText('Copy')).toBeInTheDocument();
+    expect(screen.queryByText('Copied!')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/organisms/CurlBuilderForm/CurlBuilderForm.tsx
+++ b/src/components/organisms/CurlBuilderForm/CurlBuilderForm.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import React, {useState, useMemo, useEffect} from 'react';
+
+type Method = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+
+interface Header {
+  key: string;
+  value: string;
+}
+
+const CurlBuilderForm = (): React.JSX.Element => {
+  const [url, setUrl] = useState('');
+  const [method, setMethod] = useState<Method>('GET');
+  const [headers, setHeaders] = useState<Header[]>([]);
+  const [body, setBody] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  // Generate curl command
+  const curlCommand = useMemo(() => {
+    let cmd = 'curl';
+
+    // Method
+    if (method !== 'GET') {
+      cmd += ` -X ${method}`;
+    }
+
+    // URL
+    if (url) {
+      cmd += ` "${url}"`;
+    } else {
+      cmd += ' ""';
+    }
+
+    // Headers
+    for (const h of headers) {
+      if (h.key || h.value) {
+        cmd += ` -H "${h.key}: ${h.value}"`;
+      }
+    }
+
+    // Body
+    if (['POST', 'PUT', 'PATCH'].includes(method) && body) {
+      // Escape single quotes: ' -> '\''
+      const escapedBody = body.replace(/'/g, "'\\''");
+      cmd += ` -d '${escapedBody}'`;
+    }
+
+    return cmd;
+  }, [url, method, headers, body]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(curlCommand);
+      setCopied(true);
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+    }
+  };
+
+  useEffect(() => {
+    if (copied) {
+      const timer = setTimeout(() => setCopied(false), 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [copied]);
+
+  const addHeader = () => {
+    setHeaders([...headers, {key: '', value: ''}]);
+  };
+
+  const removeHeader = (index: number) => {
+    const newHeaders = [...headers];
+    newHeaders.splice(index, 1);
+    setHeaders(newHeaders);
+  };
+
+  const updateHeader = (
+    index: number,
+    field: 'key' | 'value',
+    newValue: string,
+  ) => {
+    const newHeaders = [...headers];
+    newHeaders[index] = {...newHeaders[index], [field]: newValue};
+    setHeaders(newHeaders);
+  };
+
+  return (
+    <div className={'container'}>
+      <div className={'row mb-3'}>
+        <div className={'col-md-2'}>
+          <label htmlFor="methodSelect" className={'form-label'}>
+            Method
+          </label>
+          <select
+            id="methodSelect"
+            className={'form-select'}
+            value={method}
+            onChange={e => setMethod(e.target.value as Method)}
+          >
+            <option value="GET">GET</option>
+            <option value="POST">POST</option>
+            <option value="PUT">PUT</option>
+            <option value="DELETE">DELETE</option>
+            <option value="PATCH">PATCH</option>
+          </select>
+        </div>
+        <div className={'col-md-10'}>
+          <label htmlFor="urlInput" className={'form-label'}>
+            URL
+          </label>
+          <input
+            id="urlInput"
+            type="text"
+            className={'form-control'}
+            value={url}
+            placeholder="https://example.com/api?query=1"
+            onChange={e => setUrl(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className={'row mb-3'}>
+        <div className={'col-12'}>
+          <div className="d-flex justify-content-between align-items-center mb-2">
+            <label className={'form-label mb-0'}>Headers</label>
+            <button
+              type="button"
+              className={'btn btn-sm btn-outline-secondary'}
+              onClick={addHeader}
+            >
+              + Add Header
+            </button>
+          </div>
+          {headers.length === 0 && (
+            <div className="text-muted small mb-2">No headers added.</div>
+          )}
+          {headers.map((header, index) => (
+            <div key={index} className={'row mb-2'}>
+              <div className={'col-md-5'}>
+                <input
+                  type="text"
+                  className={'form-control'}
+                  placeholder="Key (e.g., Content-Type)"
+                  value={header.key}
+                  onChange={e => updateHeader(index, 'key', e.target.value)}
+                />
+              </div>
+              <div className={'col-md-6'}>
+                <input
+                  type="text"
+                  className={'form-control'}
+                  placeholder="Value (e.g., application/json)"
+                  value={header.value}
+                  onChange={e => updateHeader(index, 'value', e.target.value)}
+                />
+              </div>
+              <div className={'col-md-1 d-flex align-items-center'}>
+                <button
+                  type="button"
+                  className={'btn btn-sm btn-danger w-100'}
+                  onClick={() => removeHeader(index)}
+                  aria-label="Remove header"
+                >
+                  X
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {['POST', 'PUT', 'PATCH'].includes(method) && (
+        <div className={'row mb-3 form-floating'}>
+          <textarea
+            id="bodyTextarea"
+            className={'form-control'}
+            style={{height: 150}}
+            value={body}
+            placeholder="Request Body"
+            onChange={e => setBody(e.target.value)}
+          />
+          <label htmlFor={'bodyTextarea'} style={{left: '12px'}}>
+            Body
+          </label>
+        </div>
+      )}
+
+      <div className={'row mb-3 mt-4'}>
+        <div className={'col-12'}>
+          <label className={'form-label fw-bold'}>Generated curl Command</label>
+          <div className="position-relative">
+            <textarea
+              className={'form-control bg-light'}
+              style={{height: 120, fontFamily: 'monospace'}}
+              readOnly
+              value={curlCommand}
+            />
+            <button
+              type="button"
+              className={`btn btn-sm position-absolute top-0 end-0 m-2 ${
+                copied ? 'btn-success' : 'btn-primary'
+              }`}
+              onClick={handleCopy}
+            >
+              {copied ? 'Copied!' : 'Copy'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CurlBuilderForm;


### PR DESCRIPTION
This pull request adds a new Developer Help Tool: the Curl Builder Tool. It allows users to quickly generate `curl` commands using a dynamic form where they can specify the URL, HTTP Method, Headers, and Body.

### Features
- Real-time `curl` command generation.
- Dynamic addition/removal of Headers.
- Smart body visibility (only shown for POST, PUT, PATCH).
- Automatic single-quote escaping in the body text.
- One-click copy-to-clipboard functionality.

### Testing
- Jest test suite for the component and the page ensuring state handling and output generation correctness.
- Playwright E2E test suite simulating real-user navigation and form interaction.

---
*PR created automatically by Jules for task [8158655514335888386](https://jules.google.com/task/8158655514335888386) started by @eno314*