### PR TITLE
docs: Update JSON tool descriptions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@
 
 当アプリケーションでは、以下のツールを提供しています。
 
-- **JSON Parse Tool**: JSONをパースして整形・検証するツールです。
 - **JSON Compare Tool**: 2つのJSONを比較し、差分を確認できるツールです。
 - **String Replace Tool**: 文字列の検索・置換を簡単に行うツールです。
-- **Encode And Decode Tool**: URLとBase64形式のエンコードおよびデコードを行うツールです。
+- **Encode And Decode Tool**: URLとBase64、JSON形式のエンコードおよびデコードを行うツールです。
 - **Url Parse Tool**: URLをパースし、クエリパラメータ等を組み立てるツールです。
 - **Amidakuji Tool**: あみだくじ（Ghost Leg）を作成・実行できるツールです。
 - **Curl Builder Tool**: HTTPリクエストを構築し、cURLコマンドを生成するツールです。


### PR DESCRIPTION
As requested, the entry for "JSON Parse Tool" was entirely removed from `README.md`. Also, the description for "Encode And Decode Tool" was updated to mention JSON formatting and parsing (`URLとBase64、JSON形式のエンコードおよびデコードを行うツールです。`). Tested and verified via `npm test` without any errors.

---
*PR created automatically by Jules for task [1863159266249726468](https://jules.google.com/task/1863159266249726468) started by @eno314*