### PR TITLE
Migrate Url Parse Tool to Hono SPA

### DIFF
--- a/playwright_tests/hono/urlParse.spec.ts
+++ b/playwright_tests/hono/urlParse.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Url Parse Tool (Hono)", () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to the Hono proof-of-concept page
+    await page.goto("http://localhost:8000/url/parse/index.html");
+  });
+
+  test("should parse URL with multibyte query parameters", async ({ page }) => {
+    // Input URL with multibyte query parameter
+    const inputUrl = "https://example.com/search?q=テスト&lang=ja";
+
+    // Fill the parsed URL input
+    await page.locator('#parsedUrl').fill(inputUrl);
+
+    // Click the parse button
+    await page.locator('#parseUrlBtn').click();
+
+    // Verify Base URL
+    await expect(page.locator('#baseUrl')).toHaveValue(
+      "https://example.com/search",
+    );
+
+    // Verify URL parameters in the table
+    // Row 1 (q=テスト)
+    await expect(
+      page.locator("tbody tr:nth-child(1) td:nth-child(1) input"),
+    ).toHaveValue("q");
+    await expect(
+      page.locator("tbody tr:nth-child(1) td:nth-child(2) input"),
+    ).toHaveValue("テスト");
+
+    // Row 2 (lang=ja)
+    await expect(
+      page.locator("tbody tr:nth-child(2) td:nth-child(1) input"),
+    ).toHaveValue("lang");
+    await expect(
+      page.locator("tbody tr:nth-child(2) td:nth-child(2) input"),
+    ).toHaveValue("ja");
+  });
+
+  test("should build URL with multibyte encoding and parameter deletion", async ({ page }) => {
+    // Fill the Base URL input
+    await page
+      .locator('#baseUrl')
+      .fill("https://example.com/search");
+
+    // Add first parameter (q=テスト)
+    await page.locator('#addParamBtn').click();
+    await page.locator("tbody tr:nth-child(1) td:nth-child(1) input").fill("q");
+    await page
+      .locator("tbody tr:nth-child(1) td:nth-child(2) input")
+      .fill("テスト");
+
+    // Add second parameter (lang=ja)
+    await page.locator('#addParamBtn').click();
+    await page
+      .locator("tbody tr:nth-child(2) td:nth-child(1) input")
+      .fill("lang");
+    await page
+      .locator("tbody tr:nth-child(2) td:nth-child(2) input")
+      .fill("ja");
+
+    // Delete the second parameter (lang=ja)
+    await page
+      .locator("tbody tr:nth-child(2) td:nth-child(3) button", {
+        hasText: "delete",
+      })
+      .click();
+
+    // Click the build button
+    await page.locator('#buildUrlBtn').click();
+
+    // Verify the output in the Parsed URL input
+    const expectedUrl =
+      "https://example.com/search?q=%E3%83%86%E3%82%B9%E3%83%88";
+    await expect(
+      page.locator('#parsedUrl'),
+    ).toHaveValue(expectedUrl);
+  });
+});

--- a/public_hono/url/parse/index.html
+++ b/public_hono/url/parse/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Developer Help Tool - Url Parse Tool (Hono)</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+</head>
+<body>
+  <div class="container mt-4">
+    <h2>Developer Help Tool - Url Parse Tool</h2>
+    <div class="card mt-4">
+      <div class="card-header">
+        Url Parse Tool
+      </div>
+      <div class="card-body">
+        <div class="container">
+          <div class="input-group mb-3">
+            <span class="input-group-text" id="parsedUrlLabel">
+              Parsed URL
+            </span>
+            <input
+              type="url"
+              class="form-control"
+              aria-describedby="parsedUrlLabel"
+              id="parsedUrl"
+            />
+          </div>
+
+          <div class="row" style="margin-top: 10px; margin-bottom: 10px;">
+            <div class="col text-center">
+              <button
+                type="button"
+                class="btn btn-primary"
+                id="parseUrlBtn"
+              >
+                ▼ Parse URL
+              </button>
+            </div>
+            <div class="col text-center">
+              <button
+                type="button"
+                class="btn btn-primary"
+                id="buildUrlBtn"
+              >
+                ▲ Build URL
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <div class="input-group mb-3">
+              <span class="input-group-text" id="baseUrlLabel">
+                Base URL
+              </span>
+              <input
+                type="url"
+                class="form-control"
+                aria-describedby="baseUrlLabel"
+                id="baseUrl"
+              />
+            </div>
+
+            <table class="table table-sm">
+              <thead>
+                <tr>
+                  <th scope="col">URL PARAM KEY</th>
+                  <th scope="col">URL PARAM VALUE</th>
+                  <th scope="col">DELETE</th>
+                </tr>
+              </thead>
+              <tbody id="urlParamsTableBody">
+                <!-- Rows will be populated here -->
+              </tbody>
+            </table>
+
+            <div style="text-align: center;">
+              <button
+                type="button"
+                class="btn btn-secondary"
+                id="addParamBtn"
+              >
+                add param
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="main.js"></script>
+</body>
+</html>

--- a/public_hono/url/parse/main.js
+++ b/public_hono/url/parse/main.js
@@ -1,0 +1,147 @@
+// Logic from urlParseUtils.ts (Inline for SPA prototype)
+
+const parseUrl = (url) => {
+  try {
+    const parsedUrl = new URL(url);
+
+    const urlParams = [];
+    parsedUrl.searchParams.forEach((value, key) => {
+      urlParams.push({ key, value });
+    });
+
+    return {
+      baseUrlText: `${parsedUrl.protocol}//${parsedUrl.hostname}${parsedUrl.pathname}`,
+      urlParams,
+    };
+  } catch (_e) {
+    return { baseUrlText: "", urlParams: [] };
+  }
+};
+
+const createUrlText = (baseUrlText, urlParams) => {
+  const params = urlParams
+    .filter((urlParam) => urlParam.key.length > 0 && urlParam.value)
+    .map((urlParam) => {
+      const encodedValue = encodeURIComponent(urlParam.value);
+      return `${urlParam.key}=${encodedValue}`;
+    })
+    .join("&");
+
+  if (params.length === 0) {
+    return baseUrlText;
+  } else {
+    return `${baseUrlText}?${params}`;
+  }
+};
+
+const updateUrlParams = (base, index, type, value) => {
+  const urlParams = Array.from(base);
+  urlParams[index][type] = value;
+  return urlParams;
+};
+
+const removeUrlParamOf = (index, urlParams) => {
+  const newUrlParams = Array.from(urlParams);
+  newUrlParams.splice(index, 1);
+  return newUrlParams;
+};
+
+const addUrlParam = (urlParams) => {
+  const newUrlParams = Array.from(urlParams);
+  newUrlParams.push({ key: "", value: "" });
+  return newUrlParams;
+};
+
+// State
+let parsedUrlText = "";
+let baseUrlText = "";
+let urlParams = [];
+
+// DOM Elements
+const parsedUrlInput = document.getElementById("parsedUrl");
+const baseUrlInput = document.getElementById("baseUrl");
+const parseUrlBtn = document.getElementById("parseUrlBtn");
+const buildUrlBtn = document.getElementById("buildUrlBtn");
+const urlParamsTableBody = document.getElementById("urlParamsTableBody");
+const addParamBtn = document.getElementById("addParamBtn");
+
+// Render Functions
+const render = () => {
+  parsedUrlInput.value = parsedUrlText;
+  baseUrlInput.value = baseUrlText;
+
+  // Render table rows
+  urlParamsTableBody.innerHTML = "";
+  urlParams.forEach((param, i) => {
+    const tr = document.createElement("tr");
+
+    // Key Input
+    const tdKey = document.createElement("td");
+    const inputKey = document.createElement("input");
+    inputKey.type = "text";
+    inputKey.className = "form-control";
+    inputKey.value = param.key;
+    inputKey.addEventListener("input", (e) => {
+      urlParams = updateUrlParams(urlParams, i, "key", e.target.value);
+    });
+    tdKey.appendChild(inputKey);
+
+    // Value Input
+    const tdValue = document.createElement("td");
+    const inputValue = document.createElement("input");
+    inputValue.type = "text";
+    inputValue.className = "form-control";
+    inputValue.value = param.value;
+    inputValue.addEventListener("input", (e) => {
+      urlParams = updateUrlParams(urlParams, i, "value", e.target.value);
+    });
+    tdValue.appendChild(inputValue);
+
+    // Delete Button
+    const tdDelete = document.createElement("td");
+    const deleteBtn = document.createElement("button");
+    deleteBtn.type = "button";
+    deleteBtn.className = "btn btn-secondary btn-sm";
+    deleteBtn.textContent = "delete";
+    deleteBtn.addEventListener("click", () => {
+      urlParams = removeUrlParamOf(i, urlParams);
+      render(); // re-render needed after delete
+    });
+    tdDelete.appendChild(deleteBtn);
+
+    tr.appendChild(tdKey);
+    tr.appendChild(tdValue);
+    tr.appendChild(tdDelete);
+
+    urlParamsTableBody.appendChild(tr);
+  });
+};
+
+// Event Listeners
+parsedUrlInput.addEventListener("input", (e) => {
+  parsedUrlText = e.target.value;
+});
+
+baseUrlInput.addEventListener("input", (e) => {
+  baseUrlText = e.target.value;
+});
+
+parseUrlBtn.addEventListener("click", () => {
+  const result = parseUrl(parsedUrlText);
+  baseUrlText = result.baseUrlText;
+  urlParams = result.urlParams;
+  render();
+});
+
+buildUrlBtn.addEventListener("click", () => {
+  parsedUrlText = createUrlText(baseUrlText, urlParams);
+  render();
+});
+
+addParamBtn.addEventListener("click", () => {
+  urlParams = addUrlParam(urlParams);
+  render();
+});
+
+// Initial render
+render();

--- a/src/components/molecules/UrlParseForm/UrlParseForm.tsx
+++ b/src/components/molecules/UrlParseForm/UrlParseForm.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import React, { type ChangeEvent, useState } from "react";
-
-interface UrlParam {
-  key: string;
-  value: string;
-}
+import {
+  type UrlParam,
+  parseUrl,
+  createUrlText,
+  updateUrlParams,
+  removeUrlParamOf,
+  addUrlParam,
+} from "../../../utils/urlParseUtils.ts";
 
 const styles = {
   primaryButtonsRow: {
@@ -143,62 +146,6 @@ const UrlParseForm = (): React.JSX.Element => {
       </div>
     </div>
   );
-};
-
-const updateUrlParams = (
-  base: UrlParam[],
-  index: number,
-  type: string,
-  value: string,
-): UrlParam[] => {
-  const urlParams = Array.from(base);
-  urlParams[index][type] = value;
-  return urlParams;
-};
-
-const parseUrl = (
-  url: string,
-): { baseUrlText: string; urlParams: UrlParam[] } => {
-  const parsedUrl = new URL(url);
-
-  const urlParams: UrlParam[] = [];
-  parsedUrl.searchParams.forEach((value: string, key: string) => {
-    urlParams.push({ key, value });
-  });
-
-  return {
-    baseUrlText:
-      `${parsedUrl.protocol}//${parsedUrl.hostname}${parsedUrl.pathname}`,
-    urlParams,
-  };
-};
-
-const createUrlText = (baseUrlText: string, urlParams: UrlParam[]): string => {
-  const params = urlParams
-    .filter((urlParam: UrlParam) => urlParam.key.length > 0 && urlParam.value)
-    .map((urlParam: UrlParam) => {
-      const encodedValue = encodeURIComponent(urlParam.value);
-      return `${urlParam.key}=${encodedValue}`;
-    })
-    .join("&");
-
-  if (params.length === 0) {
-    return baseUrlText;
-  } else {
-    return `${baseUrlText}?${params}`;
-  }
-};
-
-const removeUrlParamOf = (index: number, urlParams: UrlParam[]): UrlParam[] => {
-  const newUrlParams = Array.from(urlParams);
-  newUrlParams.splice(index, 1);
-  return newUrlParams;
-};
-
-const addUrlParam = (urlParams: UrlParam[]): UrlParam[] => {
-  const newUrlParams = Array.from(urlParams);
-  newUrlParams.push({ key: "", value: "" });
-  return newUrlParams;
 };
 
 export default UrlParseForm;

--- a/src/utils/urlParseUtils.test.ts
+++ b/src/utils/urlParseUtils.test.ts
@@ -1,0 +1,89 @@
+import { expect } from "@std/expect";
+import {
+  parseUrl,
+  createUrlText,
+  updateUrlParams,
+  removeUrlParamOf,
+  addUrlParam,
+} from "./urlParseUtils.ts";
+
+Deno.test("urlParseUtils - parseUrl", () => {
+  const result = parseUrl("https://example.com/path?key1=value1&key2=value2");
+  expect(result.baseUrlText).toBe("https://example.com/path");
+  expect(result.urlParams).toEqual([
+    { key: "key1", value: "value1" },
+    { key: "key2", value: "value2" },
+  ]);
+});
+
+Deno.test("urlParseUtils - parseUrl with multibyte chars", () => {
+  const urlToParse = `https://example.com/path?key1=${encodeURIComponent("あいうえお")}`;
+  const result = parseUrl(urlToParse);
+  expect(result.baseUrlText).toBe("https://example.com/path");
+  expect(result.urlParams).toEqual([
+    { key: "key1", value: "あいうえお" },
+  ]);
+});
+
+Deno.test("urlParseUtils - parseUrl with invalid url", () => {
+  const result = parseUrl("not_a_valid_url");
+  expect(result.baseUrlText).toBe("");
+  expect(result.urlParams).toEqual([]);
+});
+
+Deno.test("urlParseUtils - createUrlText", () => {
+  const baseUrlText = "https://example.com/path";
+  const urlParams = [
+    { key: "key1", value: "value1" },
+    { key: "key2", value: "value2" },
+  ];
+  const result = createUrlText(baseUrlText, urlParams);
+  expect(result).toBe("https://example.com/path?key1=value1&key2=value2");
+});
+
+Deno.test("urlParseUtils - createUrlText with multibyte chars", () => {
+  const baseUrlText = "https://example.com/path";
+  const urlParams = [
+    { key: "key1", value: "あいうえお" },
+  ];
+  const result = createUrlText(baseUrlText, urlParams);
+  expect(result).toBe(`https://example.com/path?key1=${encodeURIComponent("あいうえお")}`);
+});
+
+Deno.test("urlParseUtils - createUrlText with empty params", () => {
+  const baseUrlText = "https://example.com/path";
+  const urlParams = [
+    { key: "", value: "value1" }, // Invalid key
+    { key: "key2", value: "" },   // Invalid value
+  ];
+  const result = createUrlText(baseUrlText, urlParams);
+  expect(result).toBe("https://example.com/path");
+});
+
+Deno.test("urlParseUtils - updateUrlParams", () => {
+  const baseParams = [
+    { key: "key1", value: "value1" },
+  ];
+  const result = updateUrlParams(baseParams, 0, "value", "newValue1");
+  expect(result).toEqual([{ key: "key1", value: "newValue1" }]);
+});
+
+Deno.test("urlParseUtils - removeUrlParamOf", () => {
+  const baseParams = [
+    { key: "key1", value: "value1" },
+    { key: "key2", value: "value2" },
+  ];
+  const result = removeUrlParamOf(0, baseParams);
+  expect(result).toEqual([{ key: "key2", value: "value2" }]);
+});
+
+Deno.test("urlParseUtils - addUrlParam", () => {
+  const baseParams = [
+    { key: "key1", value: "value1" },
+  ];
+  const result = addUrlParam(baseParams);
+  expect(result).toEqual([
+    { key: "key1", value: "value1" },
+    { key: "", value: "" },
+  ]);
+});

--- a/src/utils/urlParseUtils.ts
+++ b/src/utils/urlParseUtils.ts
@@ -1,0 +1,63 @@
+export interface UrlParam {
+  key: string;
+  value: string;
+}
+
+export const updateUrlParams = (
+  base: UrlParam[],
+  index: number,
+  type: "key" | "value",
+  value: string,
+): UrlParam[] => {
+  const urlParams = Array.from(base);
+  urlParams[index][type] = value;
+  return urlParams;
+};
+
+export const parseUrl = (
+  url: string,
+): { baseUrlText: string; urlParams: UrlParam[] } => {
+  try {
+    const parsedUrl = new URL(url);
+
+    const urlParams: UrlParam[] = [];
+    parsedUrl.searchParams.forEach((value: string, key: string) => {
+      urlParams.push({ key, value });
+    });
+
+    return {
+      baseUrlText: `${parsedUrl.protocol}//${parsedUrl.hostname}${parsedUrl.pathname}`,
+      urlParams,
+    };
+  } catch (_e) {
+    return { baseUrlText: "", urlParams: [] };
+  }
+};
+
+export const createUrlText = (baseUrlText: string, urlParams: UrlParam[]): string => {
+  const params = urlParams
+    .filter((urlParam: UrlParam) => urlParam.key.length > 0 && urlParam.value)
+    .map((urlParam: UrlParam) => {
+      const encodedValue = encodeURIComponent(urlParam.value);
+      return `${urlParam.key}=${encodedValue}`;
+    })
+    .join("&");
+
+  if (params.length === 0) {
+    return baseUrlText;
+  } else {
+    return `${baseUrlText}?${params}`;
+  }
+};
+
+export const removeUrlParamOf = (index: number, urlParams: UrlParam[]): UrlParam[] => {
+  const newUrlParams = Array.from(urlParams);
+  newUrlParams.splice(index, 1);
+  return newUrlParams;
+};
+
+export const addUrlParam = (urlParams: UrlParam[]): UrlParam[] => {
+  const newUrlParams = Array.from(urlParams);
+  newUrlParams.push({ key: "", value: "" });
+  return newUrlParams;
+};


### PR DESCRIPTION
This commit migrates the "Url Parse Tool" to the new Hono SPA architecture based on the Iterative Migration plan (Step 3). The business logic was cleanly extracted from the Next.js component to a reusable TypeScript utility function with full Deno unit test coverage. A lightweight vanilla JS SPA prototype has been created in `public_hono`, and Playwright E2E tests verify that both the legacy Next.js application and the new Hono SPA function perfectly.

---
*PR created automatically by Jules for task [5000086283701201178](https://jules.google.com/task/5000086283701201178) started by @eno314*