### PR TITLE
ci: fix setup-pages failing to get pages site by enabling enablement

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Added `enablement: true` to the `actions/configure-pages@v5` action in `.github/workflows/main.yml` to automatically enable and configure GitHub Pages for the repository. This fixes the "Not Found" error that occurs when GitHub Pages is not yet enabled or configured to build using GitHub Actions.

---
*PR created automatically by Jules for task [16766642645017778871](https://jules.google.com/task/16766642645017778871) started by @eno314*