### PR TITLE
ci: add dist artifact upload to workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,13 @@ jobs:
       - name: Build Application
         run: deno task build
 
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-preview
+          path: dist/
+          retention-days: 7
+
       - name: Install Playwright Browsers
         run: deno run -A npm:playwright install --with-deps chromium
 


### PR DESCRIPTION
This pull request adds an `actions/upload-artifact@v4` step to the CI workflow in `.github/workflows/main.yml`. 

It uploads the `dist/` directory generated by the `deno task build` step as an artifact named `dist-preview` with a 7-day retention policy. 
This provides a way to download the built frontend files directly from the GitHub Actions run summary page, making it easier to verify changes locally before merging a PR.

---
*PR created automatically by Jules for task [9159082347248072662](https://jules.google.com/task/9159082347248072662) started by @eno314*