### PR TITLE
Fix index page links for GitHub Pages

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -21,7 +21,7 @@
           <ul class="list-group">
             <li class="list-group-item">
               <a
-                href="/json/compare/index.html"
+                href="./json/compare/index.html"
                 class="text-decoration-none fw-bold"
               >JSON Compare Tool</a>
               <p class="mb-0 text-muted small">
@@ -30,7 +30,7 @@
             </li>
             <li class="list-group-item">
               <a
-                href="/string/replace/index.html"
+                href="./string/replace/index.html"
                 class="text-decoration-none fw-bold"
               >String Replace Tool</a>
               <p class="mb-0 text-muted small">
@@ -39,7 +39,7 @@
             </li>
             <li class="list-group-item">
               <a
-                href="/encodeDecode/index.html"
+                href="./encodeDecode/index.html"
                 class="text-decoration-none fw-bold"
               >Encode And Decode Tool</a>
               <p class="mb-0 text-muted small">
@@ -48,7 +48,7 @@
             </li>
             <li class="list-group-item">
               <a
-                href="/url/parse/index.html"
+                href="./url/parse/index.html"
                 class="text-decoration-none fw-bold"
               >Url Parse Tool</a>
               <p class="mb-0 text-muted small">
@@ -57,7 +57,7 @@
             </li>
             <li class="list-group-item">
               <a
-                href="/amidakuji/index.html"
+                href="./amidakuji/index.html"
                 class="text-decoration-none fw-bold"
               >Amidakuji Tool</a>
               <p class="mb-0 text-muted small">
@@ -66,7 +66,7 @@
             </li>
             <li class="list-group-item">
               <a
-                href="/curl/builder/index.html"
+                href="./curl/builder/index.html"
                 class="text-decoration-none fw-bold"
               >Curl Builder Tool</a>
               <p class="mb-0 text-muted small">
@@ -75,7 +75,7 @@
             </li>
             <li class="list-group-item">
               <a
-                href="/timestamp/index.html"
+                href="./timestamp/index.html"
                 class="text-decoration-none fw-bold"
               >Timestamp Tool</a>
               <p class="mb-0 text-muted small">


### PR DESCRIPTION
Fixes broken links on the main index page when deployed to GitHub Pages.
Because the app is deployed under the `/DeveloperHelpTool/` subpath, absolute root paths (`/json/...`) fail to resolve. Updating them to relative paths (`./json/...`) allows Vite and the browser to correctly resolve them against the configured base URL.

This has been tested locally by building the project (`deno task build`) and running the Playwright test suite (`deno run -A npm:playwright test`), as well as visual inspection of screenshots, confirming the JS/CSS files load perfectly.

---
*PR created automatically by Jules for task [6967558228749385846](https://jules.google.com/task/6967558228749385846) started by @eno314*