### PR TITLE
Fix Amidakuji Tool alignment to lock labels perfectly with grid lines

### DIFF
--- a/src/client/.vite/deps/_metadata.json
+++ b/src/client/.vite/deps/_metadata.json
@@ -1,0 +1,8 @@
+{
+  "hash": "0aaef278",
+  "configHash": "f6ab37d2",
+  "lockfileHash": "e3b0c442",
+  "browserHash": "1dcdea5d",
+  "optimized": {},
+  "chunks": {}
+}

--- a/src/client/.vite/deps/package.json
+++ b/src/client/.vite/deps/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/src/client/amidakuji/index.html
+++ b/src/client/amidakuji/index.html
@@ -13,25 +13,34 @@
     <style>
       .amidakujiBoard {
         margin-top: 30px;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
         width: 100%;
         overflow-x: auto;
+        display: flex;
+        justify-content: center;
+      }
+      .amidakujiInner {
+        position: relative;
+        width: 100%;
+        max-width: 1000px;
+        min-width: 300px; /* Ensure labels don't overlap too much on small screens */
+        padding: 0 40px; /* Protect edge labels from being clipped by translateX(-50%) */
+        box-sizing: border-box;
       }
       .labelsRow {
-        display: flex;
-        justify-content: space-between;
+        position: relative;
         width: 100%;
-        min-width: 300px;
-        padding: 0 50px; /* match SVG paddingX */
+        height: 80px; /* Space for label and select button */
+      }
+      .labelsRow.bottomLabelsRow {
+        height: 40px; /* Space for label only */
       }
       .labelContainer {
+        position: absolute;
         display: flex;
         flex-direction: column;
         align-items: center;
         width: 60px;
-        flex-shrink: 0;
+        transform: translateX(-50%);
       }
       .labelInput {
         text-align: center;
@@ -41,14 +50,13 @@
       }
       .svgWrapper {
         width: 100%;
-        min-width: 300px;
         margin: 10px 0;
-        display: flex;
-        justify-content: center;
       }
       .svgContainer {
         display: block;
-        max-width: 1000px;
+        width: 100%;
+        height: 400px; /* Fix height to prevent infinite scaling */
+        overflow: visible; /* Prevent clipping */
       }
     </style>
   </head>
@@ -92,14 +100,16 @@
           </div>
 
           <div class="amidakujiBoard" id="boardContainer">
-            <!-- Top Labels -->
-            <div class="labelsRow" id="topLabelsContainer"></div>
+            <div class="amidakujiInner">
+              <!-- Top Labels -->
+              <div class="labelsRow" id="topLabelsContainer"></div>
 
-            <!-- SVG -->
-            <div class="svgWrapper" id="svgWrapper"></div>
+              <!-- SVG -->
+              <div class="svgWrapper" id="svgWrapper"></div>
 
-            <!-- Bottom Labels -->
-            <div class="labelsRow" id="bottomLabelsContainer"></div>
+              <!-- Bottom Labels -->
+              <div class="labelsRow bottomLabelsRow" id="bottomLabelsContainer"></div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/client/amidakuji/main.ts
+++ b/src/client/amidakuji/main.ts
@@ -137,11 +137,17 @@ function render() {
     isEndNodeArray[endPoint.col] = true;
   }
 
+  const getColPercent = (col: number) => {
+    if (state.numLines <= 1) return 50;
+    return (col / (state.numLines - 1)) * 100;
+  };
+
   // Top Labels
   topLabelsContainer.innerHTML = "";
   state.topLabels.forEach((label, i) => {
     const container = document.createElement("div");
     container.className = "labelContainer";
+    container.style.left = `${getColPercent(i)}%`;
 
     const input = document.createElement("input");
     input.type = "text";
@@ -176,6 +182,7 @@ function render() {
   state.bottomLabels.forEach((label, i) => {
     const container = document.createElement("div");
     container.className = "labelContainer";
+    container.style.left = `${getColPercent(i)}%`;
 
     const input = document.createElement("input");
     input.type = "text";
@@ -196,21 +203,18 @@ function render() {
   });
 
   // SVG
-  const width = 100 * (state.numLines - 1);
-  const height = 400;
-  const paddingX = 50;
-  const paddingY = 20;
+  const width = 100;
+  const height = 400; // Keep height relatively large to maintain line aspect ratio in percentage space
   const rowSpacing = height / (ROWS + 1);
-  const colSpacing = width / (state.numLines - 1 || 1);
 
-  const getX = (col: number) => paddingX + col * colSpacing;
-  const getY = (row: number) => paddingY + (row + 1) * rowSpacing;
+  const getX = (col: number) => getColPercent(col);
+  const getY = (row: number) => (row + 1) * rowSpacing;
 
   let svgHtml = `
     <svg
       width="100%"
       height="100%"
-      viewBox="0 0 ${width + paddingX * 2} ${height + paddingY * 2}"
+      viewBox="0 0 ${width} ${height}"
       preserveAspectRatio="none"
       class="svgContainer"
     >
@@ -218,9 +222,7 @@ function render() {
 
   // Vertical lines
   for (let i = 0; i < state.numLines; i++) {
-    svgHtml += `<line x1="${getX(i)}" y1="${paddingY}" x2="${getX(i)}" y2="${
-      paddingY + height
-    }" stroke="#ccc" stroke-width="4" vector-effect="non-scaling-stroke" />`;
+    svgHtml += `<line x1="${getX(i)}" y1="0" x2="${getX(i)}" y2="${height}" stroke="#ccc" stroke-width="4" vector-effect="non-scaling-stroke" />`;
   }
 
   // Horizontal lines
@@ -243,9 +245,9 @@ function render() {
     const points = selectedPath
       .map((p) => {
         const y = p.row === -1
-          ? paddingY
+          ? 0
           : p.row === ROWS
-          ? paddingY + height
+          ? height
           : getY(p.row);
         return `${getX(p.col)},${y}`;
       })


### PR DESCRIPTION
Addresses an issue in the Amidakuji Tool where the top choices and bottom goals were misaligned with the vertical game board lines.

**Changes:**
- Updated CSS in `src/client/amidakuji/index.html` to establish an `amidakujiInner` relative container, protecting elements from overflowing edges while allowing the inner content to precisely center via `translateX(-50%)`.
- Replaced pixel-based coordinate mapping in `src/client/amidakuji/main.ts` with percentage-based `%` mapping, ensuring the SVG lines and the HTML input elements share the identical 0-100 scaling domain.
- Fixed the SVG height to an exact `400px` value to preserve normal dimensions under `preserveAspectRatio="none"` preventing severe unbounded vertical scaling.
- Verified visual fidelity successfully locally across narrow and wide viewpoints.

---
*PR created automatically by Jules for task [5524696327186651160](https://jules.google.com/task/5524696327186651160) started by @eno314*