### PR TITLE
fix: String Count Tool のテキストエリアの高さが正しくならない問題を修正

### DIFF
--- a/src/ui/string/count/App.svelte
+++ b/src/ui/string/count/App.svelte
@@ -25,7 +25,7 @@
     <textarea
       class="form-control textarea"
       id="inputTextarea"
-      style="height: 800px"
+      style="height: 450px"
       bind:value={inputStr}
     ></textarea>
     <label for="inputTextarea">

--- a/src/ui/string/count/App.svelte
+++ b/src/ui/string/count/App.svelte
@@ -10,7 +10,6 @@
 
 <style>
   .textarea {
-    height: 800px;
     margin-top: 5px;
     margin-bottom: 5px;
   }
@@ -26,6 +25,7 @@
     <textarea
       class="form-control textarea"
       id="inputTextarea"
+      style="height: 800px"
       bind:value={inputStr}
     ></textarea>
     <label for="inputTextarea">


### PR DESCRIPTION
Bootstrapの `form-floating` の影響で、 String Count Tool のテキストエリアの高さが正しく800pxに表示されない問題を修正しました。`<textarea>` に直接 `style="height: 800px"` を付与することで高さを強制するようにしました。不要になった `<style>` の定義も削除しています。

---
*PR created automatically by Jules for task [16251337214690977892](https://jules.google.com/task/16251337214690977892) started by @eno314*