### PR TITLE
feat: Add key order vs element comparison status to JSON Compare Tool

### DIFF
--- a/playwright_tests/jsonCompare.spec.ts
+++ b/playwright_tests/jsonCompare.spec.ts
@@ -33,6 +33,11 @@ test("JSON Compare Tool correctly parses and compares JSON strings", async ({ pa
   await expect(page.getByText("Left Result")).toBeVisible();
   await expect(page.getByText("Right Result")).toBeVisible();
 
+  // Status alert should show "different elements"
+  const statusAlert = page.locator("#compareStatusAlert");
+  await expect(statusAlert).toBeVisible();
+  await expect(statusAlert).toContainText("要素の相違");
+
   // "age": 30 should be present and marked as removed on the left side
   const leftRemovedSpan = page.locator("span.removed");
   await expect(leftRemovedSpan).toContainText('"age": 30');
@@ -41,6 +46,46 @@ test("JSON Compare Tool correctly parses and compares JSON strings", async ({ pa
   const rightAddedSpan = page.locator("span.added");
   await expect(rightAddedSpan).toContainText('"age": 31');
   await expect(rightAddedSpan).toContainText('"city": "New York"');
+});
+
+test("JSON Compare Tool shows exact match status for identical JSON strings", async ({ page }) => {
+  await page.goto(
+    "http://localhost:8000/DeveloperHelpTool/json/compare/",
+  );
+
+  const leftTextarea = page.locator("textarea").nth(0);
+  const rightTextarea = page.locator("textarea").nth(1);
+  const compareButton = page.getByRole("button", { name: "Compare" });
+
+  await leftTextarea.fill('{"a": 1, "b": 2}');
+  await rightTextarea.fill('{"a": 1, "b": 2}');
+  await compareButton.click();
+
+  const statusAlert = page.locator("#compareStatusAlert");
+  await expect(statusAlert).toBeVisible();
+  await expect(statusAlert).toContainText("完全一致");
+});
+
+test("JSON Compare Tool shows key order differs status when only key order is different", async ({ page }) => {
+  await page.goto(
+    "http://localhost:8000/DeveloperHelpTool/json/compare/",
+  );
+
+  const leftTextarea = page.locator("textarea").nth(0);
+  const rightTextarea = page.locator("textarea").nth(1);
+  const compareButton = page.getByRole("button", { name: "Compare" });
+
+  // Same elements but different key order
+  await leftTextarea.fill('{"b": 2, "a": 1}');
+  await rightTextarea.fill('{"a": 1, "b": 2}');
+  await compareButton.click();
+
+  const statusAlert = page.locator("#compareStatusAlert");
+  await expect(statusAlert).toBeVisible();
+  await expect(statusAlert).toContainText("キー順序のみ相違");
+
+  // Diff should still show differences (raw input is compared)
+  await expect(page.locator("span.removed")).toBeVisible();
 });
 
 test("JSON Compare Tool correctly parses and compares from uploaded JSON files", async ({ page }) => {
@@ -79,4 +124,9 @@ test("JSON Compare Tool correctly parses and compares from uploaded JSON files",
 
   await expect(page.getByText("Left Result")).toBeVisible();
   await expect(page.getByText("Right Result")).toBeVisible();
+
+  // Should show "different elements" since age differs
+  const statusAlert = page.locator("#compareStatusAlert");
+  await expect(statusAlert).toBeVisible();
+  await expect(statusAlert).toContainText("要素の相違");
 });

--- a/src/domain/jsonCompare.ts
+++ b/src/domain/jsonCompare.ts
@@ -4,6 +4,26 @@ export interface JsonCompareResult {
   errorMessage: string;
   leftDifferences: DiffResult[];
   rightDifferences: DiffResult[];
+  isEqual: boolean;
+  isEqualIgnoringKeyOrder: boolean;
+}
+
+/**
+ * Recursively sorts the keys of an object.
+ */
+function sortObjectKeys(value: any): any {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(sortObjectKeys);
+  }
+  const sortedKeys = Object.keys(value).sort();
+  const sortedObj: Record<string, any> = {};
+  for (const key of sortedKeys) {
+    sortedObj[key] = sortObjectKeys(value[key]);
+  }
+  return sortedObj;
 }
 
 /**
@@ -28,6 +48,8 @@ export function compareJson(
       errorMessage: "Left JSON is invalid.",
       leftDifferences: [],
       rightDifferences: [],
+      isEqual: false,
+      isEqualIgnoringKeyOrder: false,
     };
   }
 
@@ -38,11 +60,22 @@ export function compareJson(
       errorMessage: "Right JSON is invalid.",
       leftDifferences: [],
       rightDifferences: [],
+      isEqual: false,
+      isEqualIgnoringKeyOrder: false,
     };
   }
 
   const formattedLeft = JSON.stringify(parsedLeft, null, 2);
   const formattedRight = JSON.stringify(parsedRight, null, 2);
+
+  const isEqual = formattedLeft === formattedRight;
+
+  const sortedLeft = sortObjectKeys(parsedLeft);
+  const sortedRight = sortObjectKeys(parsedRight);
+  const formattedSortedLeft = JSON.stringify(sortedLeft, null, 2);
+  const formattedSortedRight = JSON.stringify(sortedRight, null, 2);
+
+  const isEqualIgnoringKeyOrder = formattedSortedLeft === formattedSortedRight;
 
   const differences = diffLines(formattedLeft, formattedRight);
 
@@ -52,5 +85,11 @@ export function compareJson(
   // Right view should not contain "removed" lines
   const rightDifferences = differences.filter((part) => !part.removed);
 
-  return { errorMessage: "", leftDifferences, rightDifferences };
+  return {
+    errorMessage: "",
+    leftDifferences,
+    rightDifferences,
+    isEqual,
+    isEqualIgnoringKeyOrder,
+  };
 }

--- a/src/domain/jsonCompare.ts
+++ b/src/domain/jsonCompare.ts
@@ -11,17 +11,18 @@ export interface JsonCompareResult {
 /**
  * Recursively sorts the keys of an object.
  */
-function sortObjectKeys(value: any): any {
+function sortObjectKeys(value: unknown): unknown {
   if (value === null || typeof value !== "object") {
     return value;
   }
   if (Array.isArray(value)) {
     return value.map(sortObjectKeys);
   }
-  const sortedKeys = Object.keys(value).sort();
-  const sortedObj: Record<string, any> = {};
+  const obj = value as Record<string, unknown>;
+  const sortedKeys = Object.keys(obj).sort();
+  const sortedObj: Record<string, unknown> = {};
   for (const key of sortedKeys) {
-    sortedObj[key] = sortObjectKeys(value[key]);
+    sortedObj[key] = sortObjectKeys(obj[key]);
   }
   return sortedObj;
 }

--- a/src/ui/json/compare/App.svelte
+++ b/src/ui/json/compare/App.svelte
@@ -9,6 +9,8 @@
   let leftDifferences = $state<DiffResult[]>([]);
   let rightDifferences = $state<DiffResult[]>([]);
   let showResult = $state(false);
+  let isEqual = $state(false);
+  let isEqualIgnoringKeyOrder = $state(false);
 
   function handleFileChange(side: "left" | "right") {
     return (e: Event) => {
@@ -43,6 +45,8 @@
     errorMessage = result.errorMessage;
     leftDifferences = result.leftDifferences;
     rightDifferences = result.rightDifferences;
+    isEqual = result.isEqual;
+    isEqualIgnoringKeyOrder = result.isEqualIgnoringKeyOrder;
 
     if (!errorMessage) {
       showResult = true;
@@ -138,6 +142,26 @@
   </div>
 
   {#if showResult}
+    <div class="row mb-3">
+      <div class="col">
+        {#if isEqual}
+          <div class="alert alert-success" id="compareStatusAlert" role="alert">
+            <strong>完全一致 (Exact Match):</strong> JSONは完全に一致しています。 (The JSON inputs are exactly identical.)
+          </div>
+        {:else}
+          {#if isEqualIgnoringKeyOrder}
+            <div class="alert alert-warning" id="compareStatusAlert" role="alert">
+              <strong>キー順序のみ相違 (Key Order Differs):</strong> キーの並び順のみが異なります。要素（キーと値）は一致しています。 (Only the parameter ordering differs; all elements and values match.)
+            </div>
+          {:else}
+            <div class="alert alert-danger" id="compareStatusAlert" role="alert">
+              <strong>要素の相違 (Different Elements):</strong> JSONの要素（キーまたは値）が異なっています。 (The JSON elements or values themselves are different.)
+            </div>
+          {/if}
+        {/if}
+      </div>
+    </div>
+
     <div id="diffResultContainer" class="row">
       <div class="col-md-6">
         <h4>Left Result</h4>

--- a/tests/domain/jsonCompare.test.ts
+++ b/tests/domain/jsonCompare.test.ts
@@ -83,4 +83,36 @@ Deno.test("compareJson", async (t) => {
     );
     expect(leftAddedOrRemoved).toBe(false);
   });
+
+  await t.step("identifies key order differences correctly", () => {
+    const leftJson = `{"b": 2, "a": 1}`;
+    const rightJson = `{"a": 1, "b": 2}`;
+
+    const result = compareJson(leftJson, rightJson);
+    expect(result.errorMessage).toBe("");
+    expect(result.isEqual).toBe(false);
+    expect(result.isEqualIgnoringKeyOrder).toBe(true);
+    // Diff is on raw input, so there should be differences shown
+    expect(result.leftDifferences.some((d) => d.removed)).toBe(true);
+  });
+
+  await t.step("identifies actual element differences correctly", () => {
+    const leftJson = `{"b": 2, "a": 1}`;
+    const rightJson = `{"a": 1, "b": 3}`;
+
+    const result = compareJson(leftJson, rightJson);
+    expect(result.errorMessage).toBe("");
+    expect(result.isEqual).toBe(false);
+    expect(result.isEqualIgnoringKeyOrder).toBe(false);
+  });
+
+  await t.step("identifies exactly identical JSONs correctly", () => {
+    const leftJson = `{"a": 1, "b": {"c": 3}}`;
+    const rightJson = `{"a": 1, "b": {"c": 3}}`;
+
+    const result = compareJson(leftJson, rightJson);
+    expect(result.errorMessage).toBe("");
+    expect(result.isEqual).toBe(true);
+    expect(result.isEqualIgnoringKeyOrder).toBe(true);
+  });
 });


### PR DESCRIPTION
## 概要

JSON Compareページにパラメータの並び順と要素の違いを区別して確認できる機能を追加しました。

## 新機能

Compareボタンを押した後、常に以下のいずれかのステータスアラートが表示されます：

| ステータス | アラート色 | 条件 |
|---|---|---|
| **完全一致 (Exact Match)** | 🟢 成功（緑） | JSONが完全に一致している |
| **キー順序のみ相違 (Key Order Differs)** | 🟡 警告（黄） | キーの並び順のみが異なり、要素は一致している |
| **要素の相違 (Different Elements)** | 🔴 エラー（赤） | キーまたは値が異なっている |

差分表示（Diff view）はオリジナルの入力順序のまま行われます。

## 変更ファイル

### `src/domain/jsonCompare.ts`
- `sortObjectKeys` ヘルパー関数を追加（JSONオブジェクトキーを再帰的にソート）
- `JsonCompareResult` インターフェースに `isEqual` / `isEqualIgnoringKeyOrder` フラグを追加
- `compareJson` 関数を更新（常にオリジナル入力でdiff、フラグを返す）

### `src/ui/json/compare/App.svelte`
- Compareボタン押下後に上記3種類のステータスアラートを表示するよう更新

### `tests/domain/jsonCompare.test.ts`
- キー順序差分・要素差分・完全一致に関するユニットテストを追加

### `playwright_tests/jsonCompare.spec.ts`
- 完全一致・キー順序のみ相違・要素の相違それぞれのE2Eテストを追加
- 既存テストにステータスアラートの検証を追加

## テスト結果

- ユニットテスト: `deno test -A` → 64 passed
- E2Eテスト: Playwright chromium → 4 passed